### PR TITLE
memul: nfc: Advertise extended length support for IsoDep frames

### DIFF
--- a/configs/libnfc-brcm.conf
+++ b/configs/libnfc-brcm.conf
@@ -315,3 +315,10 @@ PRESERVE_STORAGE=0x00
 ###############################################################################
 # NCI Hal Module name
 NCI_HAL_MODULE="nfc_nci.pn54x"
+
+###############################################################################
+# Set max transceive length for IsoDep frames
+# Standard      0x105 (261)
+# Extended      0xFEFF (65279)
+ISO_DEP_MAX_TRANSCEIVE=0xFEFF
+


### PR DESCRIPTION
Device-side change for fix of [BUGBASH-1063](https://jira.lineageos.org/browse/BUGBASH-1063).

As the headline suggests it advertises extended length support the NXP PN54x chips are capable of. Verified working with German ID card on the One Mini 2.